### PR TITLE
Readme-Fix: Remove unsafe download link and replace it with repo zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     ```
     pip install sleepeegpy
     ```
-4. [Download](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/NirLab-TAU/sleepeegpy/tree/main/notebooks) notebooks.
+4. [Download](https://github.com/NirLab-TAU/sleepeegpy/archive/refs/heads/main.zip) this repository zip folder, you will need only the notebooks folder.
 
 ## Quickstart
 1. Open the complete pipeline notebook in the created environment.


### PR DESCRIPTION
The current link is marked by Google as not safe. 
The new link is a link to the repo zip (which will download both the notebooks and the sleepeeg library)

(Optional future suggestion: Considering split the library and the notebooks, to separate the library from the notebooks. The current instructions are better fit for the notebooks, not for the library repo)